### PR TITLE
Improves schedulers

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -269,26 +269,44 @@ arrow_conda_python_builders = docker_builders_for(
 
 arrow_builders = (
     arrow_cpp_builders +
-    arrow_cpp_benchmark_builders +
     arrow_python_builders +
     arrow_conda_cpp_builders +
     arrow_conda_python_builders
+)
+
+arrow_benchmark_builders = (
+    arrow_cpp_benchmark_builders
 )
 
 if conf.projects.ursabot.enabled:
     c['builders'].extend(ursabot_builders)
 
 if conf.projects.arrow.enabled:
-    c['builders'].extend(arrow_builders)
+    c['builders'].extend(arrow_builders + arrow_benchmark_builders)
 
 ################################ SCHEDULERS ###################################
 
-c['schedulers'].append(
-    ForceScheduler(
-        name='force',
-        builders=c['builders']
-    )
-)
+force_schedulers = []
+
+if conf.projects.arrow.enabled:
+    force_schedulers.append(ForceScheduler(
+        project='apache/arrow',
+        name='apache-arrow-force-scheduler',
+        buttonName='Build',
+        label='Manual apache/arrow Build',
+        builders=arrow_builders + arrow_benchmark_builders
+    ))
+
+if conf.projects.ursabot.enabled:
+    force_schedulers.append(ForceScheduler(
+        project='ursa-labs/ursabot',
+        name='ursabot-force-scheduler',
+        buttonName='Build',
+        label='Manual ursa-labs/ursabot Build',
+        builders=ursabot_builders
+    ))
+
+c['schedulers'].extend(force_schedulers)
 
 if conf.schedulers['try'].enabled:
     c['schedulers'].append(
@@ -319,6 +337,18 @@ arrow_schedulers = [
         ),
         treeStableTimer=None,
         builders=arrow_builders
+    ) ,
+    # Ensure that benchmarks are not triggered on every commit of every PR.
+    # A benchmark build is triggered by any changes with the property
+    # `is_benchmark` which is provided by a custom ForceScheduler.
+    AnyBranchScheduler(
+        name='arrow-benchmarks',
+        change_filter=util.ChangeFilter(
+            project='apache/arrow',
+            filter_fn=lambda c: c.properties.getProperty('is_benchmark')
+        ),
+        treeStableTimer=None,
+        builders=arrow_cpp_benchmark_builders
     )
 ]
 

--- a/master.cfg
+++ b/master.cfg
@@ -334,6 +334,7 @@ arrow_schedulers = [
         name='arrow',
         change_filter=util.ChangeFilter(
             project='apache/arrow',
+            filter_fn=lambda c: not c.properties.getProperty('is_benchmark')
         ),
         treeStableTimer=None,
         builders=arrow_builders

--- a/master.cfg
+++ b/master.cfg
@@ -340,7 +340,7 @@ arrow_schedulers = [
     ) ,
     # Ensure that benchmarks are not triggered on every commit of every PR.
     # A benchmark build is triggered by any changes with the property
-    # `is_benchmark` which is provided by a custom ForceScheduler.
+    # `is_benchmark`.
     AnyBranchScheduler(
         name='arrow-benchmarks',
         change_filter=util.ChangeFilter(

--- a/ursabot/hooks.py
+++ b/ursabot/hooks.py
@@ -59,7 +59,7 @@ class GithubHook(GitHubEventHandler):
         elif command is None:
             # ursabot is not mentioned, nothing to do
             return [], 'git'
-        elif command == 'build':
+        elif command in ('build', 'benchmark'):
             if 'pull_request' not in issue:
                 message = 'Ursabot only listens to pull request comments!'
                 await self._post(comments_url, {'body': message})
@@ -76,7 +76,8 @@ class GithubHook(GitHubEventHandler):
                 'sender': payload['sender'],
                 'repository': payload['repository'],
                 'pull_request': pull_request,
-                'number': pull_request['number']
+                'number': pull_request['number'],
+                'is_benchmark': command == 'benchmark'
             }, event)
         except Exception as e:
             message = "I've failed to start builds for this PR"

--- a/ursabot/schedulers.py
+++ b/ursabot/schedulers.py
@@ -1,4 +1,4 @@
-from buildbot.plugins import schedulers
+from buildbot.plugins import schedulers, util
 
 
 class SchedulerMixin:
@@ -8,7 +8,25 @@ class SchedulerMixin:
         super().__init__(*args, builderNames=builder_names, **kwargs)
 
 
-class ForceScheduler(SchedulerMixin, schedulers.ForceScheduler):
+class GithubSchedulerMixin:
+    """ Improves the default form of ForceScheduler. """
+
+    def __init__(self, *args, project, **kwargs):
+        codebase = util.CodebaseParameter(
+            codebase='',
+            label='',
+            branch=util.StringParameter(name='branch',
+                                        default='master',
+                                        required=True),
+            commit=util.StringParameter(name='commit', required=True),
+            project=util.FixedParameter(name='project', default=project),
+            repository=util.FixedParameter(name='repository', default=project),
+        )
+        super().__init__(*args, codebases=[codebase], **kwargs)
+
+
+class ForceScheduler(SchedulerMixin, GithubSchedulerMixin,
+                     schedulers.ForceScheduler):
     pass
 
 


### PR DESCRIPTION
- Ensures that GithubPRPoller doesn't trigger benchmark builds.
  Closes #38.
- Improve ForceScheduler form. Closes #39.