### PR TITLE
Allow docker hostconfig in configuration

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -186,7 +186,7 @@ for worker in conf.workers:
             image=util.Property('docker_image'),
             autopull=True,
             alwaysPull=True,
-            hostconfig=dict(network_mode='host')
+            hostconfig=worker.hostconfig
         )
     )
 

--- a/master.cfg
+++ b/master.cfg
@@ -186,7 +186,8 @@ for worker in conf.workers:
             image=util.Property('docker_image'),
             autopull=True,
             alwaysPull=True,
-            hostconfig=worker.hostconfig
+            hostconfig=worker.hostconfig,
+            max_builds=worker.get('max_builds', 1)
         )
     )
 

--- a/master.cfg
+++ b/master.cfg
@@ -186,7 +186,7 @@ for worker in conf.workers:
             image=util.Property('docker_image'),
             autopull=True,
             alwaysPull=True,
-            hostconfig=worker.hostconfig,
+            hostconfig=worker.docker.hostconfig,
             max_builds=worker.get('max_builds', 1)
         )
     )

--- a/test.toml
+++ b/test.toml
@@ -16,8 +16,10 @@ database_url = 'sqlite:///ursabot.sqlite'
 name = 'local1'
 arch = 'amd64'
 docker = { host = 'unix://var/run/docker.sock' }
+hostconfig = { network_mode = 'host', cpuset_cpus = '0,1' }
 
 [[workers]]
 name = 'local2'
 arch = 'amd64'
 docker = { host = 'unix://var/run/docker.sock' }
+hostconfig = { network_mode = 'host', cpuset_cpus = '2,3' }

--- a/test.toml
+++ b/test.toml
@@ -15,11 +15,11 @@ database_url = 'sqlite:///ursabot.sqlite'
 # docker-on-mac is able to containers for multiple architectures
 name = 'local1'
 arch = 'amd64'
-docker = { host = 'unix://var/run/docker.sock' }
-hostconfig = { network_mode = 'host', cpuset_cpus = '0,1' }
+docker.host = 'unix://var/run/docker.sock'
+docker.hostconfig = { network_mode = 'host', cpuset_cpus = '0,1' }
 
 [[workers]]
 name = 'local2'
 arch = 'amd64'
-docker = { host = 'unix://var/run/docker.sock' }
-hostconfig = { network_mode = 'host', cpuset_cpus = '2,3' }
+docker.host = 'unix://var/run/docker.sock'
+docker.hostconfig = { network_mode = 'host', cpuset_cpus = '2,3' }


### PR DESCRIPTION
This gives control on setting cpuset with `cpuset_cpus` options, and
eventually maximum memory.