### PR TITLE
Implement GitHubReviewPush

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -11,7 +11,7 @@ from buildbot.plugins import worker, steps, changes, util, reporters
 from ursabot.hooks import GithubHook
 from ursabot.utils import Config, ConfigError, Collection, startswith
 from ursabot.workers import DockerLatentWorker
-from ursabot.reporters import ZulipMailNotifier
+from ursabot.reporters import GitHubStatusPush, ZulipMailNotifier
 from ursabot.schedulers import AnyBranchScheduler, TryScheduler, ForceScheduler
 from ursabot.builders import (BuildFactory, Builder, UrsabotTest,
                               ArrowCppTest, ArrowCppBenchmark, ArrowPythonTest,
@@ -88,26 +88,6 @@ if conf.github.event_hook.enabled:
         }
     }
 
-################################ REPORTERS ####################################
-
-if conf.reporters.github_status.enabled:
-    c['services'].append(
-        reporters.GitHubStatusPush(
-            token=conf.github.token,
-            verbose=conf.reporters.github_status.debug,
-            context=util.Interpolate('buildbot/%(prop:buildername)s'),
-            startDescription='Build started.',
-            endDescription='Build done.'
-        )
-    )
-
-if conf.reporters.zulip.enabled:
-    c['services'].append(
-        ZulipMailNotifier(
-            zulipaddr=conf.reporters.zulip.address,
-            fromaddr=conf.reporters.zulip['from']
-        )
-    )
 
 ################################ CHANGES ######################################
 
@@ -358,3 +338,25 @@ if conf.projects.ursabot.enabled:
 
 if conf.projects.arrow.enabled:
     c['schedulers'].extend(arrow_schedulers)
+
+################################ REPORTERS ####################################
+
+if conf.reporters.github_status.enabled and conf.projects.ursabot.enabled:
+    c['services'].append(
+        GitHubStatusPush(
+            token=conf.github.token,
+            verbose=conf.reporters.github_status.debug,
+            context=util.Interpolate('buildbot/%(prop:buildername)s'),
+            startDescription='Build started.',
+            endDescription='Build done.',
+            builders=ursabot_builders
+        )
+    )
+
+if conf.reporters.zulip.enabled:
+    c['services'].append(
+        ZulipMailNotifier(
+            zulipaddr=conf.reporters.zulip.address,
+            fromaddr=conf.reporters.zulip['from']
+        )
+    )

--- a/ursabot/reporters.py
+++ b/ursabot/reporters.py
@@ -10,6 +10,7 @@ _template = u'''\
 <p><b> -- The Buildbot</b></p>
 '''
 
+
 class BuilderReporterMixin:
 
     def __init__(self, *args, builders, **kwargs):
@@ -53,9 +54,9 @@ class GitHubReviewPush(GitHubCommentPush):
                       or 'failure'.
         :param description: Short description of the status.
         :return: A deferred with the result from GitHub.
-        This code comes from txgithub by @tomprince.
-        txgithub is based on twisted's webclient agent, which is much less reliable and featureful
-        as txrequest (support for proxy, connection pool, keep alive, retry, etc)
+        This code comes from txgithub by @tomprince. txgithub is based on
+        twisted's webclient agent, which is much less reliable and featureful
+        as txrequest (support for proxy, connection pool, keep alive, etc)
         """
 
         # Convert state into the expected review status.
@@ -73,5 +74,6 @@ class GitHubReviewPush(GitHubCommentPush):
         }
 
         return self._http.post(
-            '/'.join(['/repos', repo_user, repo_name, 'pulls', issue, 'reviews']),
+            '/'.join(['/repos', repo_user,
+                      repo_name, 'pulls', issue, 'reviews']),
             json=payload)

--- a/ursabot/reporters.py
+++ b/ursabot/reporters.py
@@ -10,6 +10,12 @@ _template = u'''\
 <p><b> -- The Buildbot</b></p>
 '''
 
+class BuilderReporterMixin:
+
+    def __init__(self, *args, builders, **kwargs):
+        builder_names = [b.name for b in builders]
+        super().__init__(*args, builders=builder_names, **kwargs)
+
 
 class ZulipMailNotifier(reporters.MailNotifier):
 
@@ -23,3 +29,49 @@ class ZulipMailNotifier(reporters.MailNotifier):
         super().__init__(fromaddr=fromaddr, extraRecipients=[zulipaddr],
                          messageFormatter=formatter,
                          sendToInterestedUsers=False)
+
+
+class GitHubStatusPush(BuilderReporterMixin, reporters.GitHubStatusPush):
+    pass
+
+
+class GitHubCommentPush(BuilderReporterMixin, reporters.GitHubCommentPush):
+    pass
+
+
+class GitHubReviewPush(GitHubCommentPush):
+    name = "GitHubReviewPush"
+
+    def createStatus(self,
+                     repo_user, repo_name, sha, state, target_url=None,
+                     context=None, issue=None, description=None):
+        """
+        :param repo_user: GitHub user or organization
+        :param repo_name: Name of the repository
+        :param issue: Pull request number
+        :param state: one of the following 'pending', 'success', 'error'
+                      or 'failure'.
+        :param description: Short description of the status.
+        :return: A deferred with the result from GitHub.
+        This code comes from txgithub by @tomprince.
+        txgithub is based on twisted's webclient agent, which is much less reliable and featureful
+        as txrequest (support for proxy, connection pool, keep alive, retry, etc)
+        """
+
+        # Convert state into the expected review status.
+        review_status = {
+            'success': 'APPROVE',
+            'pending': 'PENDING',
+            'error': 'REQUEST_CHANGES',
+            'failure': 'REQUEST_CHANGES',
+        }[state]
+
+        payload = {
+            'commit_id': sha,
+            'event': review_status,
+            'body': description
+        }
+
+        return self._http.post(
+            '/'.join(['/repos', repo_user, repo_name, 'pulls', issue, 'reviews']),
+            json=payload)


### PR DESCRIPTION
- Refactor configuration such that StatusPush are only enabled for
  ursabot builders.
- Added builder Mixin similar to schedulers.
- Implement GitHubReviewPush that doesn't require GitHubApp.

Closes #46.