### PR TITLE
Isolates benchmark workers

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -162,6 +162,7 @@ for worker in conf.workers:
         DockerLatentWorker(
             f'{worker.name}-docker',
             arch=worker.arch,
+            is_benchmark=worker.get('is_benchmark', False),
             password=None,
             docker_host=worker.docker.host,
             image=util.Property('docker_image'),
@@ -172,7 +173,8 @@ for worker in conf.workers:
         )
     )
 
-workers_by_arch = workers.groupby('arch')
+workers_by_arch = workers.filter(is_benchmark=False).groupby('arch')
+bench_workers_by_arch = workers.filter(is_benchmark=True).groupby('arch')
 
 ################################ BUILDERS #####################################
 # The 'builders' list defines the Builders, which tell Buildbot how to perform
@@ -180,15 +182,15 @@ workers_by_arch = workers.groupby('arch')
 # particular build will only take place on one worker.
 
 
-def docker_builders_for(BuilderClass, images):
+def docker_builders_for(BuilderClass, images, workers_dict):
     builders = []
     for image in images:
-        if image.arch in workers_by_arch:
+        if image.arch in workers_dict:
             builders.append(
                 BuilderClass(
                     name=image.repo,
                     tags=list(image.platform),
-                    workers=workers_by_arch[image.arch],
+                    workers=workers_dict[image.arch],
                     properties=dict(docker_image=str(image))
                 )
             )
@@ -202,7 +204,8 @@ def docker_builders_for(BuilderClass, images):
 
 ursabot_builders = docker_builders_for(
     UrsabotTest,
-    ursabot_images.filter(tag='worker')
+    ursabot_images.filter(tag='worker'),
+    workers_by_arch
 )
 
 arrow_cpp_builders = docker_builders_for(
@@ -212,7 +215,8 @@ arrow_cpp_builders = docker_builders_for(
         os=startswith('ubuntu') | startswith('alpine'),
         variant=None,  # plain linux images, no conda
         tag='worker'
-    )
+    ),
+    workers_by_arch
 )
 arrow_cpp_benchmark_builders = docker_builders_for(
     ArrowCppBenchmark,
@@ -221,7 +225,8 @@ arrow_cpp_benchmark_builders = docker_builders_for(
         os=startswith('ubuntu'),
         variant=None,  # plain linux images, no conda
         tag='worker'
-    )
+    ),
+    bench_workers_by_arch
 )
 arrow_python_builders = docker_builders_for(
     ArrowPythonTest,
@@ -230,7 +235,8 @@ arrow_python_builders = docker_builders_for(
         os=startswith('ubuntu') | startswith('alpine'),
         variant=None,
         tag='worker'
-    )
+    ),
+    workers_by_arch
 )
 arrow_conda_cpp_builders = docker_builders_for(
     ArrowCppCondaTest,
@@ -238,7 +244,8 @@ arrow_conda_cpp_builders = docker_builders_for(
         name='cpp',
         variant='conda',
         tag='worker'
-    )
+    ),
+    workers_by_arch
 )
 arrow_conda_python_builders = docker_builders_for(
     ArrowPythonCondaTest,
@@ -246,7 +253,8 @@ arrow_conda_python_builders = docker_builders_for(
         name=startswith('python'),
         variant='conda',
         tag='worker'
-    )
+    ),
+    workers_by_arch
 )
 
 arrow_builders = (

--- a/prod.toml
+++ b/prod.toml
@@ -75,30 +75,35 @@ docker.hostconfig = { network_mode = 'host', cpuset_cpus = '16-19,36-39' }
 [[workers]]
 name = 'dgx2-1'
 arch = 'amd64'
+is_benchmark = true
 docker.host = 'tcp://ursa-dgx2:2375'
 docker.hostconfig = { network_mode = 'host', cpuset_cpus = '0-3,20-23' }
 
 [[workers]]
 name = 'dgx2-2'
 arch = 'amd64'
+is_benchmark = true
 docker.host = 'tcp://ursa-dgx2:2375'
 docker.hostconfig = { network_mode = 'host', cpuset_cpus = '4-7,24-27' }
 
 [[workers]]
 name = 'dgx2-3'
 arch = 'amd64'
+is_benchmark = true
 docker.host = 'tcp://ursa-dgx2:2375'
 docker.hostconfig = { network_mode = 'host', cpuset_cpus = '8-11,28-31' }
 
 [[workers]]
 name = 'dgx2-4'
 arch = 'amd64'
+is_benchmark = true
 docker.host = 'tcp://ursa-dgx2:2375'
 docker.hostconfig = { network_mode = 'host', cpuset_cpus = '12-15,32-35' }
 
 [[workers]]
 name = 'dgx2-5'
 arch = 'amd64'
+is_benchmark = true
 docker.host = 'tcp://ursa-dgx2:2375'
 docker.hostconfig = { network_mode = 'host', cpuset_cpus = '16-19,36-39' }
 

--- a/prod.toml
+++ b/prod.toml
@@ -112,4 +112,4 @@ name = 'jetson1'
 arch = 'arm64v8'
 docker.host = 'tcp://ursa-jetson1:2375'
 docker.hostconfig = { network_mode = 'host' }
-max_builds = 4
+max_builds = 1

--- a/test.toml
+++ b/test.toml
@@ -33,5 +33,6 @@ docker.hostconfig = { network_mode = 'host', cpuset_cpus = '0,1' }
 [[workers]]
 name = 'local2'
 arch = 'amd64'
+is_benchmark = true
 docker.host = 'unix://var/run/docker.sock'
 docker.hostconfig = { network_mode = 'host', cpuset_cpus = '2,3' }

--- a/ursabot/workers.py
+++ b/ursabot/workers.py
@@ -10,8 +10,9 @@ from buildbot.plugins import worker
 
 class WorkerMixin:
 
-    def __init__(self, *args, arch, **kwargs):
+    def __init__(self, *args, arch, is_benchmark=None, **kwargs):
         self.arch = arch
+        self.is_benchmark = is_benchmark
         super().__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
Ensure that workers for benchmark are not shared with standard builders.