### PR TITLE
Reduce the number of ARM builders

### DIFF
--- a/ursabot/builders.py
+++ b/ursabot/builders.py
@@ -353,11 +353,21 @@ class ArrowCppTest(DockerBuilder):
         cpp_compile,
         cpp_test
     ]
-    images = arrow_images.filter(
-        name='cpp',
-        os=startswith('ubuntu') | startswith('alpine'),
-        variant=None,  # plain linux images, not conda
-        tag='worker'
+    images = (
+        arrow_images.filter(
+            name='cpp',
+            arch='amd64',
+            os=startswith('ubuntu') | startswith('alpine'),
+            variant=None,  # plain linux images, not conda
+            tag='worker'
+        ) +
+        arrow_images.filter(
+            name='cpp',
+            arch='arm64v8',
+            os='ubuntu-18.04',
+            variant=None,  # plain linux images, not conda
+            tag='worker'
+        )
     )
 
 
@@ -400,11 +410,21 @@ class ArrowPythonTest(DockerBuilder):
         python_install,
         python_test
     ]
-    images = arrow_images.filter(
-        name=startswith('python'),
-        os=startswith('ubuntu') | startswith('alpine'),
-        variant=None,  # plain linux images, not conda
-        tag='worker'
+    images = (
+        arrow_images.filter(
+            name=startswith('python'),
+            arch='amd64',
+            os=startswith('ubuntu') | startswith('alpine'),
+            variant=None,  # plain linux images, not conda
+            tag='worker'
+        ) +
+        arrow_images.filter(
+            name=startswith('python'),
+            arch='arm64v8',
+            os='ubuntu-18.04',
+            variant=None,  # plain linux images, not conda
+            tag='worker'
+        )
     )
 
 

--- a/ursabot/utils.py
+++ b/ursabot/utils.py
@@ -77,6 +77,12 @@ class Collection(list):
     def groupby(self, *args):
         return toolz.groupby(operator.attrgetter(*args), self)
 
+    def __add__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__class__(super().__add__(other))
+        else:
+            return NotImplemented
+
 
 class ConfigError(Exception):
     pass


### PR DESCRIPTION
resolves #69 

Only the following builders are remaining:
- ARM64V8 Ubuntu 18.04 C++
- ARM64V8 Ubuntu 18.04 C++ Benchmark
- ARM64V8 Ubuntu 18.04 Python 3