### PR TITLE
Nvidia CUDA images and builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ To build and push Arrow `amd64` `conda` images:
 ursabot --verbose docker --arch amd64 --variant conda build --push
 ```
 
+To build and push Arrow `arm64v8` `alpine` images:
+
+```bash
+ursabot --verbose \
+  docker --docker-host tcp://arm-machine:2375 --arch arm64v8 --os alpine-3.9
+  build --push
+```
+
 ## Development
 
 Buildbot doesn't distribute its testing suite with binary wheels, so it must

--- a/master.cfg
+++ b/master.cfg
@@ -17,7 +17,8 @@ from ursabot.reporters import (GitHubStatusPush, GitHubReviewPush,
                                GitHubCommentPush, ZulipStatusPush)
 from ursabot.schedulers import AnyBranchScheduler, TryScheduler, ForceScheduler
 from ursabot.builders import (BuildFactory, Builder, UrsabotTest,
-                              ArrowCppTest, ArrowCppBenchmark, ArrowPythonTest,
+                              ArrowCppTest, ArrowCppCudaTest,
+                              ArrowCppBenchmark, ArrowPythonTest,
                               ArrowCppCondaTest, ArrowPythonCondaTest)
 from ursabot.docker import arrow_images, ursabot_images
 
@@ -173,6 +174,7 @@ ursabot_builders = UrsabotTest.builders_for(workers.filter(arch='amd64'))
 
 arrow_builders = (
     ArrowCppTest.builders_for(workers) +
+    ArrowCppCudaTest.builders_for(workers) +
     ArrowPythonTest.builders_for(workers) +
     ArrowCppCondaTest.builders_for(workers) +
     ArrowPythonCondaTest.builders_for(workers)

--- a/ursabot/builders.py
+++ b/ursabot/builders.py
@@ -170,7 +170,7 @@ definitions = {
     # Build the Arrow Compute Modules
     'ARROW_COMPUTE': 'ON',
     # Build the Arrow CUDA extensions (requires CUDA toolkit)
-    # 'ARROW_CUDA': 'OFF',
+    'ARROW_CUDA': 'OFF',
     # Compiler flags to append when compiling Arrow
     # 'ARROW_CXXFLAGS': '',
     # Compile with extra error context (line numbers, code)
@@ -375,6 +375,22 @@ class ArrowCppTest(DockerBuilder):
             variant=None,  # plain linux images, not conda
             tag='worker'
         )
+    )
+
+
+class ArrowCppCudaTest(ArrowCppTest):
+    tags = ['arrow', 'cpp', 'cuda']
+    properties = {
+        'ARROW_CUDA': 'ON',
+        'ARROW_PLASMA': 'ON',
+        'CMAKE_INSTALL_PREFIX': '/usr/local',
+        'CMAKE_INSTALL_LIBDIR': 'lib'
+    }
+    images = arrow_images.filter(
+        name='cpp',
+        arch='amd64',
+        variant='cuda',
+        tag='worker'
     )
 
 

--- a/ursabot/docker.py
+++ b/ursabot/docker.py
@@ -427,7 +427,7 @@ for arch in ['amd64']:
 # CUDA
 for arch in ['amd64']:
     for toolkit_version in ['10.1']:
-        basetitle = f'{arch.upper()} CUDA {toolkit_version}'
+        basetitle = f'{arch.upper()} Nvidia Cuda {toolkit_version}'
 
         cpp = DockerImage(
             name='cpp',

--- a/ursabot/docker.py
+++ b/ursabot/docker.py
@@ -315,14 +315,14 @@ arrow_images = ImageCollection()
 
 for arch in ['amd64', 'arm64v8']:
     # UBUNTU
-    for version in ['16.04', '18.04']:
-        basetitle = f'{arch.upper()} Ubuntu {version}'
+    for ubuntu_version in ['16.04', '18.04']:
+        basetitle = f'{arch.upper()} Ubuntu {ubuntu_version}'
 
         cpp = DockerImage(
             name='cpp',
-            base=f'{arch}/ubuntu:{version}',
+            base=f'{arch}/ubuntu:{ubuntu_version}',
             arch=arch,
-            os=f'ubuntu-{version}',
+            os=f'ubuntu-{ubuntu_version}',
             org='ursalab',
             title=f'{basetitle} C++',
             steps=[
@@ -338,7 +338,7 @@ for arch in ['amd64', 'arm64v8']:
         )
         arrow_images.extend([cpp, python])
 
-        if version in {'18.04'}:
+        if ubuntu_version in {'18.04'}:
             cpp_benchmark = DockerImage(
                 name='cpp-benchmark',
                 base=cpp,
@@ -351,14 +351,14 @@ for arch in ['amd64', 'arm64v8']:
             arrow_images.append(cpp_benchmark)
 
     # ALPINE
-    for version in ['3.9']:
-        basetitle = f'{arch.upper()} Alpine {version}'
+    for alpine_version in ['3.9']:
+        basetitle = f'{arch.upper()} Alpine {alpine_version}'
 
         cpp = DockerImage(
             name='cpp',
-            base=f'{arch}/alpine:{version}',
+            base=f'{arch}/alpine:{alpine_version}',
             arch=arch,
-            os=f'alpine-{version}',
+            os=f'alpine-{alpine_version}',
             title=f'{basetitle} C++',
             org='ursalab',
             steps=[
@@ -411,17 +411,44 @@ for arch in ['amd64']:
     )
     arrow_images.extend([cpp, cpp_benchmark])
 
-    for pyversion in ['2.7', '3.6', '3.7']:
+    for python_version in ['2.7', '3.6', '3.7']:
         python = DockerImage(
-            name=f'python-{pyversion}',
+            name=f'python-{python_version}',
             base=cpp,
-            title=f'{basetitle} Python {pyversion}',
+            title=f'{basetitle} Python {python_version}',
             steps=[
                 ADD(docker_assets / 'conda-python.txt'),
-                RUN(conda(f'python={pyversion}', files=['conda-python.txt']))
+                RUN(conda(f'python={python_version}',
+                          files=['conda-python.txt']))
             ]
         )
         arrow_images.append(python)
+
+# CUDA
+for arch in ['amd64']:
+    for toolkit_version in {'10.1'}:
+        basetitle = f'{arch.upper()} CUDA {toolkit_version}'
+
+        cpp = DockerImage(
+            name='cpp',
+            base=f'nvidia/cuda:{toolkit_version}-devel-ubuntu18.04',
+            arch=arch,
+            os=f'ubuntu-18.04',
+            org='ursalab',
+            variant='cuda',
+            title=f'{basetitle} C++',
+            steps=[
+                RUN(apt(*ubuntu_pkgs, 'python3', 'python3-pip')),
+                RUN(symlink(python_symlinks))
+            ]
+        )
+        python = DockerImage(
+            name='python-3',
+            base=cpp,
+            title=f'{basetitle} Python 3',
+            steps=python_steps
+        )
+        arrow_images.extend([cpp, python])
 
 
 # none of the above images are usable as buildbot workers until We install,

--- a/ursabot/docker.py
+++ b/ursabot/docker.py
@@ -426,7 +426,7 @@ for arch in ['amd64']:
 
 # CUDA
 for arch in ['amd64']:
-    for toolkit_version in {'10.1'}:
+    for toolkit_version in ['10.1']:
         basetitle = f'{arch.upper()} CUDA {toolkit_version}'
 
         cpp = DockerImage(
@@ -455,7 +455,6 @@ for arch in ['amd64']:
 # configure and set it as the command of the docker image
 worker_command = 'twistd --pidfile= -ny buildbot.tac'
 worker_steps = [
-    ENV(LC_ALL='C.UTF-8', LANG='C.UTF-8'),
     RUN(pip('buildbot-worker')),
     RUN(mkdir('/buildbot')),
     ADD(docker_assets / 'buildbot.tac', '/buildbot/buildbot.tac'),

--- a/ursabot/steps.py
+++ b/ursabot/steps.py
@@ -217,7 +217,6 @@ class Ninja(ShellCommand):
 class CTest(ShellCommand):
     name = 'CTest'
     command = ['ctest']
-    args = ['--verbose']
 
 
 class SetupPy(ShellCommand):
@@ -242,3 +241,4 @@ GitHub = steps.GitHub
 class Archery(ResultLogMixin, ShellCommand):
     name = 'Archery'
     command = ['archery']
+    env = dict(LC_ALL='C.UTF-8', LANG='C.UTF-8')  # required for click


### PR DESCRIPTION
We still need to configure workers to user nvidia runtime: `docker run --runtime=nvidia`
Will handle and test it in a follow up PR.