### PR TITLE
Add support for filters and baseline to benchmark command

### DIFF
--- a/ursabot/builders.py
+++ b/ursabot/builders.py
@@ -468,8 +468,13 @@ class ArrowCppBenchmark(DockerBuilder):
     steps = [
         checkout_arrow,
         Pip(['install', '-e', '.'], workdir='dev/archery'),
-        Archery(args=['benchmark', 'diff', 'WORKSPACE', 'master',
-                      '--output=diff.json'],
+        Archery(args=util.FlattenList([
+                'benchmark',
+                'diff',
+                '--output=diff.json',
+                util.Property('benchmark_options', []),
+                'WORKSPACE',
+                util.Property('benchmark_baseline', 'master')]),
                 result_file='diff.json')
     ]
     images = images.filter(

--- a/ursabot/commands.py
+++ b/ursabot/commands.py
@@ -68,14 +68,53 @@ def build():
 
 
 @ursabot.command()
-@click.argument('baseline', type=str, default=None, required=False)
+@click.argument('baseline', type=str, metavar='[<baseline>]', default=None,
+                required=False)
 @click.option('--suite-filter', metavar='<regex>', show_default=True,
               type=str, default=None, help='Regex filtering benchmark suites.')
 @click.option('--benchmark-filter', metavar='<regex>', show_default=True,
               type=str, default=None,
               help='Regex filtering benchmarks.')
 def benchmark(baseline, suite_filter, benchmark_filter):
-    """Trigger all benchmarks registered for this pull request."""
+    """Run the benchmark suite in comparison mode.
+
+    This command will run the benchmark suite for tip of the branch commit
+    against `<baseline>` (or master if not provided).
+
+    Examples:
+
+    \b
+    # Run the all the benchmarks
+    \b
+    @ursabot benchmark
+
+
+    \b
+    # Compare only benchmarks where the name matches the `^Sum` regex
+    \b
+    @ursabot benchmark --benchmark-filter=^Sum
+
+    \b
+    # Compare only benchmarks where the suite matches the `compute-` regex.
+    # A suite is the C++ binary.
+    \b
+    @ursabot benchmark --suite-filter=compute-
+
+    \b
+    # Sometimes a new optimization requires the addition of new benchmarks to
+    # quantify the performance increase. When doing this be sure to add the
+    # benchmark in a separate commit before introducing the optimization.
+    #
+    # Note that specifying the baseline is the only way to compare a new
+    # benchmark, otherwise the intersection of benchmarks with master will be
+    # empty (no comparison possible).
+    #
+    # Suppose that the "MyBenchmark" benchmark is introduced in HEAD~2 and the
+    # optimization is found in HEAD. The following command will show the
+    # difference with and without the optimization on said benchmark.
+    \b
+    @ursabot benchmark --benchmark-filter=MyBenchmark HEAD~2
+    """
     # each command must return a dictionary which are set as build properties
     props = {'command': 'benchmark'}
 

--- a/ursabot/commands.py
+++ b/ursabot/commands.py
@@ -85,19 +85,15 @@ def benchmark(baseline, suite_filter, benchmark_filter):
 
     \b
     # Run the all the benchmarks
-    \b
     @ursabot benchmark
 
-
     \b
-    # Compare only benchmarks where the name matches the `^Sum` regex
-    \b
+    # Compare only benchmarks where the name matches the /^Sum/ regex
     @ursabot benchmark --benchmark-filter=^Sum
 
     \b
-    # Compare only benchmarks where the suite matches the `compute-` regex.
+    # Compare only benchmarks where the suite matches the /compute-/ regex.
     # A suite is the C++ binary.
-    \b
     @ursabot benchmark --suite-filter=compute-
 
     \b
@@ -109,10 +105,10 @@ def benchmark(baseline, suite_filter, benchmark_filter):
     # benchmark, otherwise the intersection of benchmarks with master will be
     # empty (no comparison possible).
     #
-    # Suppose that the "MyBenchmark" benchmark is introduced in HEAD~2 and the
-    # optimization is found in HEAD. The following command will show the
-    # difference with and without the optimization on said benchmark.
-    \b
+    # The following command compares the results of matching benchmarks,
+    # compiling against HEAD and the provided baseline commit (HEAD~2). You can
+    # use this to quantify the performance improvement of new optimizations or
+    # to check for regressions.
     @ursabot benchmark --benchmark-filter=MyBenchmark HEAD~2
     """
     # each command must return a dictionary which are set as build properties

--- a/ursabot/commands.py
+++ b/ursabot/commands.py
@@ -101,15 +101,15 @@ def benchmark(baseline, suite_filter, benchmark_filter):
     # quantify the performance increase. When doing this be sure to add the
     # benchmark in a separate commit before introducing the optimization.
     #
-    # Note that specifying the baseline is the only way to compare a new
+    # Note that specifying the baseline is the only way to compare using a new
     # benchmark, otherwise the intersection of benchmarks with master will be
     # empty (no comparison possible).
     #
     # The following command compares the results of matching benchmarks,
-    # compiling against HEAD and the provided baseline commit (HEAD~2). You can
-    # use this to quantify the performance improvement of new optimizations or
-    # to check for regressions.
-    @ursabot benchmark --benchmark-filter=MyBenchmark HEAD~2
+    # compiling against HEAD and the provided baseline commit, e.g. eaf8302.
+    # You can use this to quantify the performance improvement of new
+    # optimizations or to check for regressions.
+    @ursabot benchmark --benchmark-filter=MyBenchmark eaf8302
     """
     # each command must return a dictionary which are set as build properties
     props = {'command': 'benchmark'}

--- a/ursabot/commands.py
+++ b/ursabot/commands.py
@@ -68,10 +68,32 @@ def build():
 
 
 @ursabot.command()
-def benchmark():
+@click.argument('baseline', type=str, default=None, required=False)
+@click.option('--suite-filter', metavar='<regex>', show_default=True,
+              type=str, default=None, help='Regex filtering benchmark suites.')
+@click.option('--benchmark-filter', metavar='<regex>', show_default=True,
+              type=str, default=None,
+              help='Regex filtering benchmarks.')
+def benchmark(baseline, suite_filter, benchmark_filter):
     """Trigger all benchmarks registered for this pull request."""
     # each command must return a dictionary which are set as build properties
-    return {'command': 'benchmark'}
+    props = {'command': 'benchmark'}
+
+    if baseline:
+        props['benchmark_baseline'] = baseline
+
+    opts = []
+    if suite_filter:
+        suite_filter = shlex.quote(suite_filter)
+        opts.append(f'--suite-filter={suite_filter}')
+    if benchmark_filter:
+        benchmark_filter = shlex.quote(benchmark_filter)
+        opts.append(f'--benchmark-filter={benchmark_filter}')
+
+    if opts:
+        props['benchmark_options'] = opts
+
+    return props
 
 
 @ursabot.group()

--- a/ursabot/commands.py
+++ b/ursabot/commands.py
@@ -102,8 +102,8 @@ def benchmark(baseline, suite_filter, benchmark_filter):
     # benchmark in a separate commit before introducing the optimization.
     #
     # Note that specifying the baseline is the only way to compare using a new
-    # benchmark, otherwise the intersection of benchmarks with master will be
-    # empty (no comparison possible).
+    # benchmark, since master does not contain the new benchmark and no
+    # comparison is possible.
     #
     # The following command compares the results of matching benchmarks,
     # compiling against HEAD and the provided baseline commit, e.g. eaf8302.

--- a/ursabot/hooks.py
+++ b/ursabot/hooks.py
@@ -185,7 +185,7 @@ class GithubHook(GitHubEventHandler):
             return [], 'git'
 
         try:
-            command = comment['body'].split(mention)[-1].lower().strip()
+            command = comment['body'].split(mention)[-1].strip()
             properties = self.comment_handler(command)
         except CommandError as e:
             await respond(e.message, preformatted=True)


### PR DESCRIPTION
Users should be able to invoke filters and baseline commit, e.g.

`@ursabot benchmark --benchmark-filter=AFilter HEAD^2` to compare only
benchmarks matching `AFilter` against `HEAD^2` (2 commits before head).

Fixes #25 