### PR TITLE
Improve ninja concurrency

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -14,7 +14,7 @@ import toolz
 from buildbot.plugins import util, changes
 
 from ursabot.hooks import UrsabotHook
-from ursabot.utils import Config, Collection, any_of, has
+from ursabot.utils import Config, Collection, any_of, has, count_cpuspec
 from ursabot.changes import ChangeFilter, GitPoller, GitHubPullrequestPoller
 from ursabot.workers import DockerLatentWorker
 from ursabot.secrets import SecretInPass
@@ -140,7 +140,15 @@ if conf.changes.pb.enabled:
 
 workers = Collection()
 
+
 for worker in conf.workers:
+    properties = {}
+    worker_hostconfig = worker.docker.get('hostconfig', {})
+    cpuset_cpus = worker_hostconfig.get('cpuset_cpus')
+    if cpuset_cpus:
+        cpuset_cpus.split(',')
+        properties['max_concurrency'] = count_cpuspec(cpuset_cpus)
+
     workers.append(
         DockerLatentWorker(
             f'{worker.name}-docker',
@@ -155,9 +163,10 @@ for worker in conf.workers:
             alwaysPull=worker.docker.get('alwayspull', True),
             hostconfig=util.Transform(
                 toolz.merge,
+                worker_hostconfig,
                 util.Property('docker_hostconfig', default={}),
-                worker.docker.get('hostconfig', {})
             ),
+            properties=properties,
             missing_timeout=worker.docker.get('missing_timeout', 120)
         )
     )

--- a/ursabot/builders.py
+++ b/ursabot/builders.py
@@ -8,7 +8,6 @@ import copy
 import toolz
 import itertools
 import warnings
-import os
 from collections import defaultdict
 
 from buildbot import interfaces
@@ -330,9 +329,8 @@ cpp_cmake = CMake(
 
 @util.renderer
 def ninja_concurrency(props):
-    n_cpus = len(os.sched_getaffinitiy(0))
-    max_concurrency = props.getProperties('max_concurrency', default=n_cpus)
-    return [f'-j{max_concurrency}']
+    max_concurrency = props.getProperty('max_concurrency')
+    return [f'-j{max_concurrency}'] if max_concurrency else []
 
 
 cpp_compile = Ninja(

--- a/ursabot/steps.py
+++ b/ursabot/steps.py
@@ -233,9 +233,7 @@ class Env(ShellCommand):
 class Ninja(ShellCommand):
     # TODO(kszucs): add proper descriptions
     name = 'Ninja'
-    # TODO(fsaintjacques) infer the number of cpus from the environment, either
-    # the worker or before executing the command.
-    command = ['ninja', '-j6']
+    command = ['ninja']
 
 
 class CTest(ShellCommand):

--- a/ursabot/steps.py
+++ b/ursabot/steps.py
@@ -16,7 +16,7 @@ from buildbot.process.results import SUCCESS, FAILURE
 from buildbot.steps.worker import CompositeStepMixin
 from buildbot.interfaces import IRenderable
 
-from .utils import ensure_deferred, infer_number_cpus
+from .utils import ensure_deferred
 
 
 class ResultLogMixin(buildstep.BuildStep, CompositeStepMixin):
@@ -233,12 +233,9 @@ class Env(ShellCommand):
 class Ninja(ShellCommand):
     # TODO(kszucs): add proper descriptions
     name = 'Ninja'
-    command = ['ninja']
-
-    def __init__(self, parallel_jobs=None, **kwargs):
-        self.parallel_jobs = parallel_jobs or infer_number_cpus()
-        self.command.append(f'-j{self.parallel_jobs}')
-        super().__init__(**kwargs)
+    # TODO(fsaintjacques) infer the number of cpus from the environment, either
+    # the worker or before executing the command.
+    command = ['ninja', '-j6']
 
 
 class CTest(ShellCommand):

--- a/ursabot/steps.py
+++ b/ursabot/steps.py
@@ -16,7 +16,7 @@ from buildbot.process.results import SUCCESS, FAILURE
 from buildbot.steps.worker import CompositeStepMixin
 from buildbot.interfaces import IRenderable
 
-from .utils import ensure_deferred
+from .utils import ensure_deferred, infer_number_cpus
 
 
 class ResultLogMixin(buildstep.BuildStep, CompositeStepMixin):
@@ -234,6 +234,11 @@ class Ninja(ShellCommand):
     # TODO(kszucs): add proper descriptions
     name = 'Ninja'
     command = ['ninja']
+
+    def __init__(self, parallel_jobs=None, **kwargs):
+        self.parallel_jobs = parallel_jobs or infer_number_cpus()
+        self.command.append(f'-j{self.parallel_jobs}')
+        super().__init__(**kwargs)
 
 
 class CTest(ShellCommand):

--- a/ursabot/utils.py
+++ b/ursabot/utils.py
@@ -11,6 +11,7 @@ import pathlib
 import itertools
 import functools
 import operator
+import subprocess
 
 import toolz
 from ruamel.yaml import YAML
@@ -44,6 +45,11 @@ def slugify(s):
     s = re.sub(r'([A-Z])', lambda m: '-' + m.group(1).lower(), s)
     s = s.strip('-')
     return s
+
+
+def infer_number_cpus():
+    result = subprocess.run(["nproc"], capture_output=True, check=True)
+    return int(result.stdout)
 
 
 class Filter:

--- a/ursabot/utils.py
+++ b/ursabot/utils.py
@@ -47,6 +47,23 @@ def slugify(s):
     return s
 
 
+def count_cpuspec(cpuspec):
+    '''Count the number of cpus in a cpuspec, see cpuset(7) section Formats'''
+
+    cpus = set()
+    for cpuset in cpuspec.split(','):
+        a_range = cpuset.split('-')
+        if len(a_range) == 1:
+            cpus.add(int(a_range[0]))
+        if len(a_range) == 2:
+            start = int(a_range[0])
+            end = int(a_range[1])
+            if start <= end:
+                cpus.update(range(start, end + 1))
+
+    return len(cpus)
+
+
 class Filter:
 
     __slot__ = ('fn',)

--- a/ursabot/utils.py
+++ b/ursabot/utils.py
@@ -47,11 +47,6 @@ def slugify(s):
     return s
 
 
-def infer_number_cpus():
-    result = subprocess.run(["nproc"], capture_output=True, check=True)
-    return int(result.stdout)
-
-
 class Filter:
 
     __slot__ = ('fn',)

--- a/ursabot/utils.py
+++ b/ursabot/utils.py
@@ -11,7 +11,6 @@ import pathlib
 import itertools
 import functools
 import operator
-import subprocess
 
 import toolz
 from ruamel.yaml import YAML


### PR DESCRIPTION
Until https://github.com/ninja-build/ninja/issues/1278 propagates in the upstream distribution, we need to limit the number of concurrent workers.