### PR TITLE
Enable gandiva in the conda builders

### DIFF
--- a/docker/conda-cpp.txt
+++ b/docker/conda-cpp.txt
@@ -4,28 +4,29 @@
 # Use of this source code is governed by a BSD 2-Clause
 # license that can be found in the LICENSE_BSD file.
 
-# ARROW-4056: The conda-forge boost 1.69.0 seems to break the Parquet unit
-# tests with Xcode 8.3. Root cause not yet determined
-boost-cpp=1.68.0
+boost-cpp>=1.68.0
 brotli
 bzip2
 c-ares
+clangdev=7
 cmake
 double-conversion
 flatbuffers
 gflags
 glog
-gmock
-grpc-cpp
-gtest
+gmock>=1.8.1
+grpc-cpp>=1.21.4
+gtest>=1.8.1
 libprotobuf
+llvmdev=7
 lz4-c
-openssl
+ninja
+pkg-config
 python
 rapidjson
 re2
 snappy
-thrift-cpp
+thrift-cpp>=0.11.0
 uriparser
 zlib
 zstd

--- a/docker/conda-python.txt
+++ b/docker/conda-python.txt
@@ -4,12 +4,13 @@
 # Use of this source code is governed by a BSD 2-Clause
 # license that can be found in the LICENSE_BSD file.
 
-cython>=0.29.0
+cython>=0.29.7
 cloudpickle
 hypothesis
 numpy>=1.14
 pandas
 pytest
+pytest-faulthandler
 pytz
 setuptools
 setuptools_scm

--- a/docker/install_conda.sh
+++ b/docker/install_conda.sh
@@ -17,19 +17,20 @@ archs=([amd64]=x86_64
        [i386]=x86)
 
 # Validate arguments
-if [ "$#" -ne 2 ]; then
-  echo "Usage: $0 <architecture> <installation-prefix>"
-  exit
-elif [[ -z ${archs[$1]} ]]; then
-  echo "Unexpected architecture argument: ${1}"
-  exit
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 <miniconda-version> <architecture> <installation-prefix>"
+  exit 1
+elif [[ -z ${archs[$2]} ]]; then
+  echo "Unexpected architecture argument: ${2}"
+  exit 1
 fi
 
-ARCH=${archs[$1]}
-CONDA_PREFIX=$2
+VERSION=$1
+ARCH=${archs[$2]}
+CONDA_PREFIX=$3
 
 echo "Downloading Miniconda installer..."
-wget -nv https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-${ARCH}.sh -O /tmp/miniconda.sh
+wget -nv https://repo.continuum.io/miniconda/Miniconda3-${VERSION}-Linux-${ARCH}.sh -O /tmp/miniconda.sh
 bash /tmp/miniconda.sh -b -p ${CONDA_PREFIX}
 rm /tmp/miniconda.sh
 
@@ -45,6 +46,7 @@ conda config --set remote_connect_timeout_secs 12
 
 # Setup conda-forge
 conda config --add channels conda-forge
+conda config --set channel_priority strict
 
 # Update packages
 conda update --all -y

--- a/ursabot/builders.py
+++ b/ursabot/builders.py
@@ -598,7 +598,7 @@ class ArrowCppCondaTest(DockerBuilder):
         SetPropertyFromCommand(
             'ARROW_GANDIVA_PC_CXX_FLAGS',
             extract_fn=as_system_includes,
-            command=[util.Property('CXX')],
+            command=[util.Property('CXX', 'c++')],
             args=['-E', '-Wp,-v', '-xc++', '-'],
             collect_stdout=False,
             collect_stderr=True,

--- a/ursabot/cli.py
+++ b/ursabot/cli.py
@@ -74,13 +74,15 @@ def list_images(ctx):
 @docker.command()
 @click.option('--push/--no-push', '-p', default=False,
               help='Push the built images')
+@click.option('--nocache/--cache', default=False,
+              help='Do not use cache when building the images')
 @click.pass_context
-def build(ctx, push):
+def build(ctx, push, nocache):
     """Build docker images"""
     client = ctx.obj['client']
     images = ctx.obj['images']
 
-    images.build(client=client)
+    images.build(client=client, nocache=nocache)
     if push:
         images.push(client=client)
 

--- a/ursabot/steps.py
+++ b/ursabot/steps.py
@@ -11,7 +11,7 @@
 from twisted.internet import threads
 
 from buildbot.plugins import steps, util
-from buildbot.process import buildstep, logobserver
+from buildbot.process import buildstep
 from buildbot.process.results import SUCCESS, FAILURE
 from buildbot.steps.worker import CompositeStepMixin
 from buildbot.interfaces import IRenderable
@@ -156,7 +156,7 @@ class CMake(ShellMixin, steps.CMake):
 
 
 class SetPropertyFromCommand(ShellCommand):
-    name = 'SetPropertiesFromCommand'
+    name = 'SetPropertyFromCommand'
     description = ['Setting']
     descriptionDone = ['Set']
 


### PR DESCRIPTION
- new implementation for `SetPropertyFromCommand`
- unit tests for both `SetPropertyFromCommand` and `SetPropertiesFromEnv`
- enabled gandiva in the C++ and Python conda builders
- parse system includes paths of gcc and pass to clang 
- ability to build docker images with --no-cache flag enabled
- ImageCollection.build now builds those images too, which are not part of the collection, but are ancestors of the images in the collection
- reuse builder steps and properties in descendant builders