### PR TITLE
R builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,13 @@ Ursabot has a CLI interface to build the docker images:
 ursabot docker build --help
 ```
 
-To build and push Arrow C++ `amd64` `conda` images:
+To list Arrow C++ `amd64` `conda` `cpp` images:
+
+```bash
+ursabot --verbose docker --arch amd64 --variant conda --name cpp list
+```
+
+To build and push Arrow C++ `amd64` `conda` `cpp` images:
 
 ```bash
 ursabot --verbose docker --arch amd64 --variant conda --name cpp build --push

--- a/docker/conda-r.txt
+++ b/docker/conda-r.txt
@@ -1,0 +1,26 @@
+# Copyright 2019 RStudio, Inc.
+# All rights reserved.
+#
+# Use of this source code is governed by a BSD 2-Clause
+# license that can be found in the LICENSE_BSD file.
+
+r-assertthat
+r-base
+r-bit64
+r-fs
+r-purrr
+r-r6
+r-rcpp >=0.12.18.2
+r-rlang
+r-tidyselect
+
+# test dependencies
+pandoc
+r-covr
+r-hms
+r-lubridate
+r-pkgdown
+r-rmarkdown
+r-roxygen2
+r-testthat
+r-tibble

--- a/docker/conda-r.txt
+++ b/docker/conda-r.txt
@@ -15,6 +15,7 @@ r-rlang
 r-tidyselect
 
 # test dependencies
+binutils
 pandoc
 r-covr
 r-hms

--- a/docker/install_r.sh
+++ b/docker/install_r.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 RStudio, Inc.
+# All rights reserved.
+#
+# Use of this source code is governed by a BSD 2-Clause
+# license that can be found in the LICENSE_BSD file.
+
+# Exit on any error
+set -e
+
+apt-get install software-properties-common
+apt-key adv --keyserver keyserver.ubuntu.com \
+            --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/'
+apt-get update -y
+apt-get install -y r-base

--- a/docker/install_r.sh
+++ b/docker/install_r.sh
@@ -9,7 +9,10 @@
 # Exit on any error
 set -e
 
-apt-get install software-properties-common
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update -y
+apt-get install -y software-properties-common
 apt-key adv --keyserver keyserver.ubuntu.com \
             --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
 add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/'

--- a/docker/install_r.sh
+++ b/docker/install_r.sh
@@ -12,9 +12,9 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update -y
-apt-get install -y software-properties-common
+apt-get install -y software-properties-common apt-transport-https lsb-release
 apt-key adv --keyserver keyserver.ubuntu.com \
             --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
-add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/'
+add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -sc)-cran35/"
 apt-get update -y
 apt-get install -y r-base

--- a/docker/install_r_deps.R
+++ b/docker/install_r_deps.R
@@ -1,0 +1,26 @@
+#!/usr/bin/env Rscript
+#
+# Copyright 2019 RStudio, Inc.
+# All rights reserved.
+#
+# Use of this source code is governed by a BSD 2-Clause
+# license that can be found in the LICENSE_BSD file.
+
+install.packages('devtools', repos = 'http://cran.rstudio.com')
+devtools::install_github('romainfrancois/decor')
+install.packages(c(
+  'Rcpp',
+  'dplyr',
+  'stringr',
+  'glue',
+  'vctrs',
+  'purrr',
+  'assertthat',
+  'fs',
+  'tibble',
+  'crayon',
+  'testthat',
+  'bit64',
+  'hms',
+  'lubridate'
+), repos = 'https://cran.rstudio.com')

--- a/docker/install_r_deps.R
+++ b/docker/install_r_deps.R
@@ -31,7 +31,12 @@ install.packages(
     'testthat',
     'bit64',
     'hms',
-    'lubridate'
+    'lubridate',
+    'covr',
+    'lubridate',
+    'pkgdown',
+    'rmarkdown',
+    'roxygen2'
   ),
   repos = 'https://cran.rstudio.com'
 )

--- a/docker/install_r_deps.R
+++ b/docker/install_r_deps.R
@@ -6,21 +6,32 @@
 # Use of this source code is governed by a BSD 2-Clause
 # license that can be found in the LICENSE_BSD file.
 
-install.packages('devtools', repos = 'http://cran.rstudio.com')
+install.packages(
+  c(
+    'devtools',
+    'curl',
+    'xml2'
+  ),
+  repos = 'http://cran.rstudio.com'
+)
 devtools::install_github('romainfrancois/decor')
-install.packages(c(
-  'Rcpp',
-  'dplyr',
-  'stringr',
-  'glue',
-  'vctrs',
-  'purrr',
-  'assertthat',
-  'fs',
-  'tibble',
-  'crayon',
-  'testthat',
-  'bit64',
-  'hms',
-  'lubridate'
-), repos = 'https://cran.rstudio.com')
+
+install.packages(
+  c(
+    'Rcpp',
+    'dplyr',
+    'stringr',
+    'glue',
+    'vctrs',
+    'purrr',
+    'assertthat',
+    'fs',
+    'tibble',
+    'crayon',
+    'testthat',
+    'bit64',
+    'hms',
+    'lubridate'
+  ),
+  repos = 'https://cran.rstudio.com'
+)

--- a/master.cfg
+++ b/master.cfg
@@ -28,7 +28,8 @@ from ursabot.builders import (UrsabotTest, CrossbowTrigger,
                               ArrowCppBenchmark, ArrowPythonTest,
                               ArrowCppCondaTest, ArrowPythonCondaTest,
                               ArrowPythonCudaTest, ArrowJavaTest,
-                              ArrowGoTest, ArrowRustTest, ArrowJSTest)
+                              ArrowGoTest, ArrowRustTest, ArrowJSTest,
+                              ArrowRTest)
 
 # Read ursabot configuration from .toml files, export URSABOT_ENV='test' to use
 # test environment. These configurations are merged upon each other, the
@@ -232,6 +233,7 @@ cuda_enabled_workers = workers.filter(tags=has('cuda'))
 
 arrow_tests = (
     ArrowCppTest.builders_for(workers) +
+    ArrowRTest.builders_for(workers) +
     ArrowPythonTest.builders_for(workers) +
     ArrowCppCondaTest.builders_for(workers) +
     ArrowPythonCondaTest.builders_for(workers) +

--- a/master.cfg
+++ b/master.cfg
@@ -29,7 +29,7 @@ from ursabot.builders import (UrsabotTest, CrossbowTrigger,
                               ArrowCppCondaTest, ArrowPythonCondaTest,
                               ArrowPythonCudaTest, ArrowJavaTest,
                               ArrowGoTest, ArrowRustTest, ArrowJSTest,
-                              ArrowRTest)
+                              ArrowRTest, ArrowRCondaTest)
 
 # Read ursabot configuration from .toml files, export URSABOT_ENV='test' to use
 # test environment. These configurations are merged upon each other, the
@@ -236,6 +236,7 @@ arrow_tests = (
     ArrowRTest.builders_for(workers) +
     ArrowPythonTest.builders_for(workers) +
     ArrowCppCondaTest.builders_for(workers) +
+    ArrowRCondaTest.builders_for(workers) +
     ArrowPythonCondaTest.builders_for(workers) +
     ArrowCppCudaTest.builders_for(cuda_enabled_workers) +
     ArrowPythonCudaTest.builders_for(cuda_enabled_workers) +

--- a/test.yaml
+++ b/test.yaml
@@ -25,6 +25,9 @@ workers:
     ncpus: 2
     docker:
       host: 'unix://var/run/docker.sock'
+      # masterFQDN: 'host.docker.internal'  # enable it on mac
+      autopull: true
+      alwayspull: false
       hostconfig:
         network_mode: 'host'
         cpuset_cpus: '0,1'
@@ -34,6 +37,9 @@ workers:
     ncpus: 2
     docker:
       host: 'unix://var/run/docker.sock'
+      # masterFQDN: 'host.docker.internal'  # enable it on mac
+      autopull: true
+      alwayspull: false
       hostconfig:
         network_mode: 'host'
         cpuset_cpus: '2,3'

--- a/ursabot/builders.py
+++ b/ursabot/builders.py
@@ -400,7 +400,7 @@ r_deps = R(
 )
 r_build = R(args=['CMD', 'build', '.'], name='Build', workdir='r')
 r_check = R(
-    args=['CMD', 'check', 'arrow_*tar.gz'],
+    args=['CMD', 'check', 'arrow_*tar.gz', '--no-manual'],
     as_shell=True,  # to expand *
     name='Check',
     workdir='r',

--- a/ursabot/builders.py
+++ b/ursabot/builders.py
@@ -400,7 +400,7 @@ r_deps = R(
 )
 r_build = R(args=['CMD', 'build', '.'], name='Build', workdir='r')
 r_check = R(
-    args=['check', 'arrow_*tar.gz', '--as-cran', '--no-manual'],
+    args=['CMD', 'check', 'arrow_*tar.gz'],
     as_shell=True,  # to expand *
     name='Check',
     workdir='r',

--- a/ursabot/builders.py
+++ b/ursabot/builders.py
@@ -715,8 +715,7 @@ class ArrowRCondaTest(ArrowCppCondaTest):
         r_deps,
         r_build,
         r_install,
-        r_check,
-        ShellCommand(command=['sleep'], args=['3000'])
+        r_check
     ]
     images = images.filter(
         name='r',

--- a/ursabot/builders.py
+++ b/ursabot/builders.py
@@ -7,6 +7,7 @@
 import copy
 import toolz
 import itertools
+import textwrap
 import warnings
 from collections import defaultdict
 
@@ -393,7 +394,17 @@ python_test = PyTest(
 r_deps = R(
     args=[
         '-e',
-        'install.packages("remotes"); remotes::install_deps(dep = TRUE)'
+        textwrap.dedent('''
+            install.packages(
+                "remotes",
+                repo = "http://cran.rstudio.com/"
+            )
+            remotes::install_deps(
+                dependencies = TRUE,
+                upgrade = "never",
+                repos = "https://cran.rstudio.com"
+            )
+        ''')
     ],
     name='Install dependencies',
     workdir='r'
@@ -559,10 +570,9 @@ class ArrowCppBenchmark(DockerBuilder):
 
 
 class ArrowRTest(ArrowCppTest):
-    tags = ['arrow', 'R']
+    tags = ['arrow', 'r']
     steps = [
-        # *ArrowCppTest.steps[:-1],  # excluding the last test step
-        checkout_arrow,
+        *ArrowCppTest.steps[:-1],  # excluding the last test step
         r_deps,
         r_build,
         r_check
@@ -680,7 +690,7 @@ class ArrowCppCondaTest(DockerBuilder):
 
 
 class ArrowRCondaTest(ArrowCppCondaTest):
-    tags = ['arrow', 'R']
+    tags = ['arrow', 'r']
     steps = [
         *ArrowCppCondaTest.steps[:-1],  # excluding the test step
         r_deps,

--- a/ursabot/builders.py
+++ b/ursabot/builders.py
@@ -543,7 +543,8 @@ class ArrowCppBenchmark(DockerBuilder):
 class ArrowRTest(ArrowCppTest):
     tags = ['arrow', 'R']
     steps = [
-        *ArrowCppTest.steps[:-1],
+        # *ArrowCppTest.steps[:-1],
+        checkout_arrow,
         RCMD(
             args=['build', '.'],
             name='Build',
@@ -551,6 +552,7 @@ class ArrowRTest(ArrowCppTest):
         ),
         RCMD(
             args=['check', 'arrow_*tar.gz'],
+            as_shell=True,  # to expand *
             name='Check',
             workdir='r',
             env={

--- a/ursabot/cli.py
+++ b/ursabot/cli.py
@@ -62,7 +62,7 @@ def docker(ctx, docker_host, docker_username, docker_password, **kwargs):
     ctx.obj['images'] = docker_images
 
 
-@docker.command()
+@docker.command('list')
 @click.pass_context
 def list_images(ctx):
     """List the docker images"""

--- a/ursabot/docker.py
+++ b/ursabot/docker.py
@@ -531,9 +531,6 @@ for arch in ['amd64']:
             RUN(conda('benchmark', 'click', 'pandas'))
         ]
     )
-<<<<<<< HEAD
-    images.extend([cpp, cpp_benchmark, crossbow])
-=======
     r = DockerImage(
         name='r',
         base=cpp,
@@ -545,7 +542,6 @@ for arch in ['amd64']:
         ]
     )
     images.extend([crossbow, cpp, cpp_benchmark, r])
->>>>>>> ubuntu and conda images for R
 
     for python_version in ['2.7', '3.6', '3.7']:
         python = DockerImage(

--- a/ursabot/docker.py
+++ b/ursabot/docker.py
@@ -421,6 +421,15 @@ for arch in ['amd64', 'arm64v8', 'arm32v7']:
                 RUN(symlink(python_symlinks))
             ]
         )
+        cpp_benchmark = DockerImage(
+            name='cpp-benchmark',
+            base=cpp,
+            title=f'{basetitle} C++ Benchmark',
+            steps=[
+                RUN(apt('libbenchmark-dev')),
+                RUN(pip('click', 'pandas'))
+            ]
+        )
         r = DockerImage(
             name='r',
             base=cpp,
@@ -439,19 +448,7 @@ for arch in ['amd64', 'arm64v8', 'arm32v7']:
             title=f'{basetitle} Python 3',
             steps=python_steps
         )
-        images.extend([cpp, r, python])
-
-        if ubuntu_version in {'18.04'}:
-            cpp_benchmark = DockerImage(
-                name='cpp-benchmark',
-                base=cpp,
-                title=f'{basetitle} C++ Benchmark',
-                steps=[
-                    RUN(apt('libbenchmark-dev')),
-                    RUN(pip('click', 'pandas'))
-                ]
-            )
-            images.append(cpp_benchmark)
+        images.extend([cpp, cpp_benchmark, r, python])
 
     # ALPINE
     for alpine_version in ['3.9']:

--- a/ursabot/docker.py
+++ b/ursabot/docker.py
@@ -533,12 +533,9 @@ for arch in ['amd64']:
         base=cpp,
         title=f'{basetitle} R',
         steps=[
-            # install cpp dependencies
+            # install R dependencies
             ADD(docker_assets / 'conda-r.txt'),
-            RUN(conda(files=['conda-r.txt'])),
-            RUN(conda('ccache', 'tzcode')),
-            RUN(apt('tzdata')),
-            ENV(TZ='UTC')
+            RUN(conda(files=['conda-r.txt']))
         ]
     )
     images.extend([crossbow, cpp, cpp_benchmark, r])

--- a/ursabot/docker.py
+++ b/ursabot/docker.py
@@ -427,8 +427,9 @@ for arch in ['amd64', 'arm64v8', 'arm32v7']:
             title=f'{basetitle} R',
             steps=[
                 ADD(docker_assets / 'install_r.sh'),
-                ADD(docker_assets / 'install_r_deps.R'),
                 RUN('/install_r.sh'),
+                RUN(apt('libxml2-dev', 'libcurl4-openssl-dev')),
+                ADD(docker_assets / 'install_r_deps.R'),
                 RUN('/install_r_deps.R'),
             ]
         )

--- a/ursabot/docker.py
+++ b/ursabot/docker.py
@@ -406,7 +406,7 @@ images = ImageCollection()
 
 for arch in ['amd64', 'arm64v8', 'arm32v7']:
     # UBUNTU
-    for ubuntu_version in ['16.04', '18.04']:
+    for ubuntu_version in ['18.04']:
         basetitle = f'{arch.upper()} Ubuntu {ubuntu_version}'
 
         cpp = DockerImage(
@@ -417,7 +417,7 @@ for arch in ['amd64', 'arm64v8', 'arm32v7']:
             org='ursalab',
             title=f'{basetitle} C++',
             steps=[
-                RUN(apt(*ubuntu_pkgs, 'python3', 'python3-pip')),
+                RUN(apt(*ubuntu_pkgs, 'ccache', 'python3', 'python3-pip')),
                 RUN(symlink(python_symlinks))
             ]
         )
@@ -465,7 +465,7 @@ for arch in ['amd64', 'arm64v8', 'arm32v7']:
             title=f'{basetitle} C++',
             org='ursalab',
             steps=[
-                RUN(apk(*alpine_pkgs, 'python3-dev', 'py3-pip')),
+                RUN(apk(*alpine_pkgs, 'ccache', 'python3-dev', 'py3-pip')),
                 RUN(symlink(python_symlinks))
             ]
         )
@@ -520,7 +520,7 @@ for arch in ['amd64']:
             # install cpp dependencies
             ADD(docker_assets / 'conda-linux.txt'),
             ADD(docker_assets / 'conda-cpp.txt'),
-            RUN(conda(files=['conda-linux.txt', 'conda-cpp.txt'])),
+            RUN(conda('ccache', files=['conda-linux.txt', 'conda-cpp.txt'])),
         ]
     )
     cpp_benchmark = DockerImage(
@@ -539,6 +539,9 @@ for arch in ['amd64']:
             # install cpp dependencies
             ADD(docker_assets / 'conda-r.txt'),
             RUN(conda(files=['conda-r.txt'])),
+            RUN(conda('ccache', 'tzcode')),
+            RUN(apt('tzdata')),
+            ENV(TZ='UTC')
         ]
     )
     images.extend([crossbow, cpp, cpp_benchmark, r])
@@ -572,7 +575,7 @@ for arch in ['amd64']:
             runtime='nvidia',
             title=f'{basetitle} C++',
             steps=[
-                RUN(apt(*ubuntu_pkgs, 'python3', 'python3-pip')),
+                RUN(apt(*ubuntu_pkgs, 'ccache', 'python3', 'python3-pip')),
                 RUN(symlink(python_symlinks))
             ]
         )

--- a/ursabot/docker.py
+++ b/ursabot/docker.py
@@ -421,13 +421,24 @@ for arch in ['amd64', 'arm64v8', 'arm32v7']:
                 RUN(symlink(python_symlinks))
             ]
         )
+        r = DockerImage(
+            name='r',
+            base=cpp,
+            title=f'{basetitle} R',
+            steps=[
+                ADD(docker_assets / 'install_r.sh'),
+                ADD(docker_assets / 'install_r_deps.R'),
+                RUN('/install_r.sh'),
+                RUN('/install_r_deps.R'),
+            ]
+        )
         python = DockerImage(
             name='python-3',
             base=cpp,
             title=f'{basetitle} Python 3',
             steps=python_steps
         )
-        images.extend([cpp, python])
+        images.extend([cpp, r, python])
 
         if ubuntu_version in {'18.04'}:
             cpp_benchmark = DockerImage(
@@ -519,7 +530,21 @@ for arch in ['amd64']:
             RUN(conda('benchmark', 'click', 'pandas'))
         ]
     )
+<<<<<<< HEAD
     images.extend([cpp, cpp_benchmark, crossbow])
+=======
+    r = DockerImage(
+        name='cpp',
+        base=cpp,
+        title=f'{basetitle} R',
+        steps=[
+            # install cpp dependencies
+            ADD(docker_assets / 'conda-r.txt'),
+            RUN(conda(files=['conda-r.txt'])),
+        ]
+    )
+    images.extend([crossbow, cpp, cpp_benchmark, r])
+>>>>>>> ubuntu and conda images for R
 
     for python_version in ['2.7', '3.6', '3.7']:
         python = DockerImage(

--- a/ursabot/docker.py
+++ b/ursabot/docker.py
@@ -534,7 +534,7 @@ for arch in ['amd64']:
     images.extend([cpp, cpp_benchmark, crossbow])
 =======
     r = DockerImage(
-        name='cpp',
+        name='r',
         base=cpp,
         title=f'{basetitle} R',
         steps=[

--- a/ursabot/steps.py
+++ b/ursabot/steps.py
@@ -67,8 +67,6 @@ class ShellMixin(buildstep.ShellMixin):
     """
 
     shell = tuple()  # will run sh on unix and batch on windows by default
-    command = tuple()
-    args = tuple()
 
     def makeRemoteShellCommand(self, **kwargs):
         import pipes  # only available on unix
@@ -334,3 +332,8 @@ class Go(ShellCommand):
 class Cargo(ShellCommand):
     name = 'Cargo'
     command = ['cargo']
+
+
+class RCMD(ShellCommand):
+    name = 'R CMD'
+    command = ['R', 'CMD']

--- a/ursabot/steps.py
+++ b/ursabot/steps.py
@@ -301,3 +301,8 @@ class Cargo(ShellCommand):
 class R(ShellCommand):
     name = 'R'
     command = ['R']
+
+
+class Make(ShellCommand):
+    name = 'Make'
+    command = ['make']

--- a/ursabot/steps.py
+++ b/ursabot/steps.py
@@ -298,6 +298,6 @@ class Cargo(ShellCommand):
     command = ['cargo']
 
 
-class RCMD(ShellCommand):
-    name = 'R CMD'
-    command = ['R', 'CMD']
+class R(ShellCommand):
+    name = 'R'
+    command = ['R']


### PR DESCRIPTION
- remove ubuntu 16.04 docker images and builders
- install ccache in both ubuntu and conda images and mount its directory as a docker volume for caching
- ubuntu R builder
- conda R builder
- unquoted shell command
- enable parquet in the ubuntu cpp builders

Test it locally after the images are built:
```
ursabot -v docker -a amd64 -n r build
```
Then run the local buildmaster
```
buildbot restart .
```
On mac watch out for https://github.com/ursa-labs/ursabot/pull/135/files#diff-ebfcb737ca3d64fc30f0e589007d4f58R28

Then select R builder on the UI and trigger a build with the Build button at the top right corner.

cc @nealrichardson 