### PR TITLE
Remove prompt from the readme "bash" blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,20 +115,20 @@ the current directory. `master.cfg` can be passed explicitly via the `--config`
 option:
 
 ```bash
-$ ursabot -c path/to/master.cfg
+ursabot -c path/to/master.cfg
 ```
 
 Describe the loaded master configuration:
 
 ```bash
-$ ursabot desc
+ursabot desc
 ```
 
 Describe the loaded project configuration:
 
 ```bash
-$ ursabot project desc  # for master configs with a single project
-$ ursabot project -p arrow desc  # for master configs with multiple projects
+ursabot project desc  # for master configs with a single project
+ursabot project -p arrow desc  # for master configs with multiple projects
 ```
 
 ## How to validate the configurations
@@ -139,14 +139,14 @@ can be run successfully (unless there are some variables only available at
 runtime).
 
 ```bash
-$ ursabot checkconfig
+ursabot checkconfig
 ```
 
 `ursabot` command loads `master.cfg` from the current directory by default, but
 `--config` argument can be passed to explicitly define a configuration file.
 
 ```bash
-$ ursabot -c arrow/master.cfg checkconfig
+ursabot -c arrow/master.cfg checkconfig
 ```
 
 ## Run a local instance of Ursabot
@@ -154,21 +154,21 @@ $ ursabot -c arrow/master.cfg checkconfig
 After installation master's database must be initialized:
 
 ```bash
-$ ursabot -v upgrade-master
+ursabot -v upgrade-master
 ```
 
 Start/stop/restart the master:
 
 ```bash
-$ ursabot -v start|stop|restart
+ursabot -v start|stop|restart
 ```
 
 Define the configuration environment (prod|test) and start the service:
 
 ```bash
-$ export URSABOT_ENV=test  # this is the default
-$ buildbot restart ursabot
-$ tail -f ursabot/twisted.log
+export URSABOT_ENV=test  # this is the default
+buildbot restart ursabot
+tail -f ursabot/twisted.log
 ```
 
 Then open `http://localhost:8100` in the browser.
@@ -181,19 +181,19 @@ Builders can be run locally without the web interface using the
 Testing `AMD64 Conda C++` builder on master:
 
 ```bash
-$ ursabot project build 'AMD64 Conda C++'
+ursabot project build 'AMD64 Conda C++'
 ```
 
 Testing `AMD64 Conda C++` builder with github pull request number 140:
 
 ```bash
-$ ursabot project build -pr 140 'AMD64 Conda C++'
+ursabot project build -pr 140 'AMD64 Conda C++'
 ```
 
 Testing `AMD64 Conda C++` with local repository:
 
 ```bash
-$ ursabot project build -s ~/Workspace/arrow:. 'AMD64 Conda C++'
+ursabot project build -s ~/Workspace/arrow:. 'AMD64 Conda C++'
 ```
 
 Where `~/Workspace/arrow` is the path of the local Arrow repository and `.`
@@ -203,7 +203,7 @@ is the destination directory under the worker's build directory (in this case:
 Passing multiple buildbot properties for the build:
 
 ```bash
-$ ursabot project build -p prop=value -p myprop=myvalue 'AMD64 Conda C++'
+ursabot project build -p prop=value -p myprop=myvalue 'AMD64 Conda C++'
 ```
 
 ### Attach on failure
@@ -214,7 +214,7 @@ to the still running workers - where the build has previously failed.
 Use the `--attach-on-failure` or `-a` flags.
 
 ```bash
-$ ursabot project build --attach-on-failure `AMD64 Conda C++`
+ursabot project build --attach-on-failure `AMD64 Conda C++`
 ```
 
 ## Configuring Ursabot
@@ -447,11 +447,11 @@ ursabot --verbose docker --arch amd64 --variant conda --name cpp list
 Additional filtering:
 
 ```bash
-$ ursabot docker --arch amd64 list
-$ ursabot docker --arch amd64 --variant conda list
-$ ursabot docker --arch amd64 --variant conda --name cpp list
-$ ursabot docker --arch amd64 --variant conda --name cpp --tag worker list
-$ ursabot docker --arch amd64 --variant conda --name cpp --os debian-9 list
+ursabot docker --arch amd64 list
+ursabot docker --arch amd64 --variant conda list
+ursabot docker --arch amd64 --variant conda --name cpp list
+ursabot docker --arch amd64 --variant conda --name cpp --tag worker list
+ursabot docker --arch amd64 --variant conda --name cpp --os debian-9 list
 ```
 
 To build and push Arrow C++ `amd64` `conda` `cpp` images:


### PR DESCRIPTION
Or we can use "console" instead of "bash".