### PR TITLE
Limit max_builds for DockerLatentWorker by default

### DIFF
--- a/conda-ursabot.txt
+++ b/conda-ursabot.txt
@@ -13,7 +13,6 @@ click
 distro
 docker-map
 dockerpty
-pydantic
 python-dotenv
 ruamel.yaml
 tabulate

--- a/projects/arrow/arrow/builders.py
+++ b/projects/arrow/arrow/builders.py
@@ -282,7 +282,7 @@ class CrossbowTrigger(DockerBuilder):
         ),
         GitHub(
             name='Clone Crossbow',
-            repourl=util.Property('crossbow_repo'),
+            repourl=util.Interpolate('https://github.com/%(prop:crossbow_repo)s'),
             workdir='crossbow',
             branch='master',
             mode='full',

--- a/projects/arrow/arrow/builders.py
+++ b/projects/arrow/arrow/builders.py
@@ -282,7 +282,9 @@ class CrossbowTrigger(DockerBuilder):
         ),
         GitHub(
             name='Clone Crossbow',
-            repourl=util.Interpolate('https://github.com/%(prop:crossbow_repo)s'),
+            repourl=(
+                util.Interpolate('https://github.com/%(prop:crossbow_repo)s')
+            ),
             workdir='crossbow',
             branch='master',
             mode='full',

--- a/projects/arrow/arrow/commands.py
+++ b/projects/arrow/arrow/commands.py
@@ -89,8 +89,9 @@ def benchmark(baseline, suite_filter, benchmark_filter):
 @click.pass_obj
 def crossbow(props, repo):
     """Trigger crossbow builds for this pull request"""
+    # TODO(kszucs): validate the repo format
     props['command'] = 'crossbow'
-    props['crossbow_repo'] = f'https://github.com/{repo}'
+    props['crossbow_repo'] = repo
 
 
 @crossbow.command()

--- a/projects/arrow/arrow/tests/test_commands.py
+++ b/projects/arrow/arrow/tests/test_commands.py
@@ -43,11 +43,9 @@ def test_crossbow_commands(command, expected_args):
 
 
 @pytest.mark.parametrize(('command', 'expected_repo'), [
-    ('crossbow test -g docker', 'https://github.com/ursa-labs/crossbow'),
-    ('crossbow -r ursa-labs/crossbow test -g docker',
-     'https://github.com/ursa-labs/crossbow'),
-    ('crossbow -r kszucs/crossbow test -g docker',
-     'https://github.com/kszucs/crossbow'),
+    ('crossbow test -g docker', 'ursa-labs/crossbow'),
+    ('crossbow -r ursa-labs/crossbow test -g docker', 'ursa-labs/crossbow'),
+    ('crossbow -r kszucs/crossbow test -g docker', 'kszucs/crossbow'),
 ])
 def test_crossbow_repo(command, expected_repo):
     props = ursabot(command)

--- a/projects/arrow/arrow/tests/test_commands.py
+++ b/projects/arrow/arrow/tests/test_commands.py
@@ -36,7 +36,7 @@ def test_crossbow_commands(command, expected_args):
     props = ursabot(command)
     expected = {
         'command': 'crossbow',
-        'crossbow_repo': 'https://github.com/ursa-labs/crossbow',
+        'crossbow_repo': 'ursa-labs/crossbow',
         'crossbow_args': expected_args
     }
     assert props == expected

--- a/ursabot/tests/test_workers.py
+++ b/ursabot/tests/test_workers.py
@@ -15,6 +15,8 @@
 #
 # Copyright Buildbot Team Members
 
+import pytest
+from buildbot.config import ConfigErrors
 from buildbot.plugins import util
 from buildbot.test.fake import docker
 from buildbot.test.fake import fakemaster
@@ -66,7 +68,13 @@ class TestDockerLatentWorker(TestDockerLatentWorker):
         assert isinstance(bs.hostconfig, util.Transform)
 
     def test_constructor_noimage_nodockerfile(self):
-        pass  # don't raise
+        bs = self.setupWorker('bot', 'pass', 'unix:///var/run/docker.sock')
+        assert bs.image == util.Property('docker_image')
+        assert bs.max_builds == 1
+
+        with pytest.raises(ConfigErrors):
+            self.setupWorker('bot', 'pass', 'unix:///var/run/docker.sock',
+                             max_builds=2)
 
     def test_start_instance_noimage_pull(self):
         bs = self.setupWorker(


### PR DESCRIPTION
- Properly set crossbow repo in both the crossbow builder and the repoter
- limit max_builds=1 for DockerLatentWorker by default

resolves #168 