### PR TITLE
Default benchmark baseline to origin/master

### DIFF
--- a/projects/arrow/arrow/builders.py
+++ b/projects/arrow/arrow/builders.py
@@ -319,7 +319,7 @@ class CppBenchmark(DockerBuilder):
                 '--output=diff.json',
                 util.Property('benchmark_options', []),
                 'WORKSPACE',
-                util.Property('benchmark_baseline', 'master')
+                util.Property('benchmark_baseline', 'origin/master')
             ]),
             result_file='diff.json'
         )

--- a/projects/arrow/master.cfg
+++ b/projects/arrow/master.cfg
@@ -192,8 +192,7 @@ schedulers = [
             # request, see docstring of ursabot.hooks.GithubHook
             project=project,
             category='comment',
-            properties={'command': 'benchmark'},
-            files=Glob('cpp/*')
+            properties={'command': 'benchmark'}
         ),
         treeStableTimer=None,
         builders=arrow_benchmarks

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 # tests to binary wheels, but ursabot's test suite depends on
 # buildbot's so install it from source
 --no-binary buildbot
-buildbot
+buildbot<2.8
 buildbot-console-view
 buildbot-grid-view
 buildbot-waterfall-view


### PR DESCRIPTION
Buildbot will perform a merge into local master before running the benchmark. Thus `master` does not references the upstream master.